### PR TITLE
Random offset into unmatched query

### DIFF
--- a/models.py
+++ b/models.py
@@ -164,15 +164,16 @@ def get_best_matches(session, *, video,
 
 
 def get_unmatched(session, *, limit=10000):
-    sql = sa.text(
-        "select from_audio.id as from_id,"
-        "       to_audio.id as to_id "
-        "from tft.video as from_audio join tft.video as to_audio"
-        " on from_audio.id != to_audio.id "
-        "and not exists("
-        "select 1 from tft.audioswap where"
-        " tft.audioswap.from_id = from_audio.id and"
-        " tft.audioswap.to_id = to_audio.id"
-        ") limit :limit;"
-    )
+    sql = sa.text("""
+        with results as (
+            select from_audio.id as from_id, to_audio.id as to_id
+            from tft.video as from_audio join tft.video as to_audio
+            on from_audio.id != to_audio.id and not exists(
+                select 1 from tft.audioswap where
+                tft.audioswap.from_id = from_audio.id and
+                tft.audioswap.to_id = to_audio.id
+            )
+        ) select from_id, to_id from results offset (
+            select floor(random() * count(*)) from results
+        ) limit :limit;""")
     return session.bind.execute(sql, limit=limit)


### PR DESCRIPTION
Before: Process unmatched videos in order from first to last
(in practice means last videos will not get processed)
After: Process unmatched videos starting at a random offset
(not great but better)
Best?: Use tablesample. However in PostgreSQL 9.5 (at least), "The
TABLESAMPLE clause is currently accepted only on regular tables and
materialized views. According to the SQL standard it should be possible
to apply it to any FROM item."
(from https://www.postgresql.org/docs/9.5/static/sql-select.html)
